### PR TITLE
Avoid memory copies in threshold

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -284,9 +284,7 @@ class MatchedFilterControl(object):
         self.threshold_and_clusterers = []
         for seg in self.segments:
             # Need to modify threshold clustering for batch operations
-            # FIXME: This should be initialized above as a 2D array!
-            snr_mem_view = [snr[seg.analyze] for snr in self.snr_mem]
-            thresh = events.ThresholdCluster(snr_mem_view)
+            thresh = events.ThresholdCluster(self.snr_mem, seg.analyze)
             self.threshold_and_clusterers.append(thresh)
 
     def setup_standard_clustering(self):


### PR DESCRIPTION
This avoids having to reallocate the snr_mem array within the threshold code. It passes my "4 templates" check.